### PR TITLE
Need to disable SPI due to conflict

### DIFF
--- a/resources/provision.sh
+++ b/resources/provision.sh
@@ -37,6 +37,9 @@ apt-get update -y &&  apt-get upgrade -y
    echo ""
    echo 'dtoverlay=gpio-fan,gpiopin=19'
    echo ""
+   echo 'Disable SPI for now because it renders /dev/ttyAMA2 useless, which is where we get serial telem for ROS2'
+   echo 'dtparam=spi=off'
+   echo ""
 } >> /boot/firmware/config.txt
 
 #######################################################################################


### PR DESCRIPTION
Tested on multiple ARK boards.

Requires a fix for /boot/firmware/config.txt due to an SPI conflict:

[    1.837775] pinctrl-bcm2835 fe200000.gpio: pin gpio9 already requested by fe201800.serial; cannot claim for fe204000.spi
[    1.848922] pinctrl-bcm2835 fe200000.gpio: pin-9 (fe204000.spi) status -22
[    1.855964] pinctrl-bcm2835 fe200000.gpio: could not request pin 9 (gpio9) from group gpio9  on device pinctrl-bcm2711
[    1.866789] spi-bcm2835 fe204000.spi: Error applying setting, reverse things back

In the future it's probably worth figuring out how to fix just for the specific pin, but I'm not sure how to do that. And this works for now.