### PR TITLE
Add Jetson Orin Nano Docker support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,191 @@
+# Dexi OS Build System
+
+## Overview
+
+This repo builds Raspberry Pi OS images for Dexi drones using [packer-builder-arm](https://github.com/mkaczanowski/packer-builder-arm) inside Docker. The build takes a pre-baked base image (Bookworm + ROS2 Jazzy + Docker) and provisions it with all Dexi-specific packages, services, and configurations.
+
+## Supported Platforms
+
+| Platform | Build Script | Packer HCL | Provision Script | Output Image |
+|----------|-------------|-------------|-----------------|--------------|
+| **ARK CM4** | `build_raspberry_pi_os_ark_cm4.sh` | `raspberry_pi_os_ark_cm4.pkr.hcl` | `resources_raspberry_pi_os/provision_ark_cm4.sh` | `dexi_raspberry_pi_os_ark_cm4.img` (30GB, ~6GB zipped) |
+| CM5 | `build_raspberry_pi_os_cm5.sh` | `raspberry_pi_os_cm5.pkr.hcl` | `resources_raspberry_pi_os/provision_pi_os_cm5.sh` | `dexi_raspberry_pi_os_cm5.img` |
+| Pi 5 | `build_raspberry_pi_os_pi5.sh` | `raspberry_pi_os_pi5.pkr.hcl` | `resources_raspberry_pi_os/provision_pi_os_pi5.sh` | `dexi_raspberry_pi_os_pi5.img` |
+| Jetson (Docker) | `jetson/build.sh` | N/A (Dockerfile) | `jetson/Dockerfile` | `dexi-ros2-jazzy` Docker image (~3.8GB) |
+
+**Jetson notes**: Runs ROS2 Jazzy in Docker on any JetPack version. Excludes `dexi_led`, `dexi_gpio`, `camera_ros` (Pi-specific). Uses `usb_cam` for cameras. See `jetson/README.md`.
+
+## Build Prerequisites
+
+- Docker running locally
+- Base image at `base_images/bookwork_jazzy_docker_shrinked.img.gz.xz` (3.4GB)
+- Docker container tars in `resources_raspberry_pi_os/`:
+  - `dexi-droneblocks.tar` (189MB) — DroneBlocks web UI, port 80
+  - `dexi-node-red.tar` (335MB) — Node-RED, port 1880
+- PX4 firmware: `resources_raspberry_pi_os/ark_pi6x_default_v1.16.1.px4`
+
+## Running a Build (ARK CM4)
+
+```bash
+./build_raspberry_pi_os_ark_cm4.sh
+```
+
+This runs: `docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm:latest build ./raspberry_pi_os_ark_cm4.pkr.hcl`
+
+Build time: several hours (full ROS2 workspace compilation via QEMU ARM emulation).
+
+## Build Pipeline Detail
+
+### 1. Packer Setup
+- Decompresses base image from XZ (3.4GB → ~20GB → 30GB resized)
+- Creates DOS/MBR image: 256MB FAT32 boot + ext4 root
+- Enters QEMU aarch64 chroot
+
+### 2. File Provisioning
+- Copies `resources_raspberry_pi_os/` → `/tmp/resources/` inside the image
+
+### 3. Provision Script (`provision_ark_cm4.sh`)
+Runs inside the chroot and does everything below in order:
+
+#### a. System Setup
+- DNS resolver (1.1.1.1)
+- APT updates + common packages (via `apt_packages.sh`: vim, libi2c-dev, tmux, meson, ninja-build, etc.)
+- i2c-dev kernel module
+
+#### b. ROS2 Workspace — the core of the build
+```bash
+git clone -b main https://github.com/droneblocks/dexi_bringup /home/dexi/dexi_ws/src/dexi_bringup
+vcs import --input /home/dexi/dexi_ws/src/dexi_bringup/dexi.repos /home/dexi/dexi_ws/src/
+```
+Then builds ~30 ROS2 packages via `colcon build --packages-select` in dependency order.
+
+#### c. Additional Software
+- **mavlink-router** — built from source, config from `dexi_bringup/config/mavlink-router/ark_cm4_main.conf`
+- **ARK companion scripts** — cloned from `DroneBlocks/ark_companion_scripts`
+- **dexi-networking** — hotspot setup (SSID: `dexi_<MAC>`, password: `droneblocks`)
+- **Docker containers** — copies tars, creates first-boot loading service
+- **code-server** — VS Code on port 9999 (password: `droneblocks`)
+- **dexi-mavsdk** — cloned for MAVSDK examples
+
+## Git Repos & Branches
+
+### Cloned directly in provision script
+| Repo | Branch | Pinned? |
+|------|--------|---------|
+| `droneblocks/dexi_bringup` | `main` | Yes (explicit) |
+| `mavlink-router/mavlink-router` | default | No — uses latest |
+| `DroneBlocks/ark_companion_scripts` | default | No — uses latest |
+| `DroneBlocks/dexi-networking` | default | No — uses latest |
+| `DroneBlocks/dexi-mavsdk` | default | No — uses latest |
+| `DroneBlocks/node-red-dexi` | default | No — uses latest |
+
+### Pulled via `dexi.repos` (vcs import)
+| Repo | Branch | Category |
+|------|--------|----------|
+| `DroneBlocks/dexi_tools` | main | Dexi |
+| `DroneBlocks/dexi_cpp` | main | Dexi |
+| `DroneBlocks/dexi_led` | main | Dexi |
+| `DroneBlocks/dexi_interfaces` | main | Dexi |
+| `DroneBlocks/dexi_offboard` | main | Dexi |
+| `DroneBlocks/dexi_apriltag` | main | Dexi |
+| `DroneBlocks/dexi_gpio` | main | Dexi |
+| `DroneBlocks/dexi_camera` | main | Dexi |
+| `DroneBlocks/dexi_yolo` | main | Dexi |
+| `DroneBlocks/dexi_ctf` | main | Dexi |
+| `AprilRobotics/apriltag` | master | Third-party |
+| `christianrauch/apriltag_ros` | **c81c05f** (pinned commit) | Third-party |
+| `christianrauch/apriltag_msgs` | master | Third-party |
+| `fkie/async_web_server_cpp` | ros2-develop | Third-party |
+| `ros-perception/vision_opencv` | rolling | Third-party |
+| `RobotWebTools/web_video_server` | ros2 | Third-party |
+| `christianrauch/camera_ros` | main | Third-party |
+| `RobotWebTools/rosbridge_suite` | ros2 | Third-party |
+| `ros-perception/image_transport_plugins` | jazzy | Third-party |
+| `px4/px4_msgs` | release/1.16 | PX4 |
+| `micro-ROS/micro-ROS-Agent` | jazzy | micro-ROS |
+| `micro-ROS/micro_ros_msgs` | jazzy | micro-ROS |
+| `ros-tooling/topic_tools` | jazzy | ROS2 tools |
+
+### Packages in dexi.repos but NOT built in provision_ark_cm4.sh
+- `dexi_tools` — not built
+- `dexi_apriltag` — not built (but `apriltag_ros` is)
+- `dexi_ctf` — not built
+- `async_web_server_cpp` — not built
+- `web_video_server` — not built
+
+## Colcon Build Order (ARK CM4)
+
+The provision script builds packages individually in this order:
+1. rosbridge_test_msgs → rosbridge_library → rosapi_msgs → rosapi → rosbridge_msgs → rosbridge_server
+2. micro_ros_msgs → micro_ros_agent
+3. dexi_interfaces
+4. dexi_led (with Adafruit NeoPixel for CM4)
+5. dexi_gpio
+6. px4_msgs → dexi_cpp → dexi_offboard (requires lgpio built from source)
+7. image_geometry → cv_bridge → apriltag → apriltag_msgs → topic_tools_interfaces → topic_tools → compressed_image_transport → compressed_depth_image_transport → theora_image_transport → zstd_image_transport → image_transport_plugins
+8. camera_ros → dexi_camera
+9. apriltag_ros
+10. dexi_yolo (requires onnxruntime pip package)
+11. dexi_bringup
+
+## Services Installed on Image
+
+| Service | Type | Purpose |
+|---------|------|---------|
+| `dexi.service` | persistent | Main ROS2 bringup (runs as root, auto-detects CM4/CM5/Pi5) |
+| `mavlink-router.service` | persistent | MAVLink routing from FC USB to UDP endpoints |
+| `code-server.service` | persistent | VS Code web IDE on port 9999 |
+| `dexi-containers-start.service` | oneshot (first boot) | Loads Docker tars and starts containers |
+| `dexi-hotspot-setup.service` | oneshot (first boot) | Creates WiFi hotspot with MAC-based SSID |
+
+## Platform Differences (CM4 vs CM5)
+
+| Aspect | CM4 | CM5 |
+|--------|-----|-----|
+| dexi_bringup branch | main (explicit) | main (default) |
+| Boot config | `config/cm4/` | `config/cm5/` |
+| LED library | Adafruit NeoPixel | pi5neo |
+| dexi_offboard | Built | NOT built |
+| Mavlink router config | `ark_cm4_main.conf` | `main.conf` |
+| Docker containers | droneblocks + node-red | droneblocks + node-red + px4-gazebo-headless |
+
+## CI/CD
+
+GitHub Actions workflow at `.github/workflows/build-ark-cm4.yml`:
+- **Trigger**: Manual (workflow_dispatch)
+- **Runner**: self-hosted (currently local Mac)
+- **Steps**: checkout → docker build → zip → upload artifact (7-day retention)
+- **Note**: Has hardcoded local path for base_images mount
+
+## Known Issues / Cautions
+
+- `set -e` is commented out in `provision_ark_cm4.sh` — build errors are silently ignored
+- `exec 2>/dev/null` suppresses all stderr — errors are invisible during build
+- Several repos are cloned without branch pins (mavlink-router, ark_companion_scripts, etc.) — builds may not be reproducible
+- The base image (`bookwork_jazzy_docker_shrinked.img.gz.xz`) is not version-controlled or hosted — lives only in local `base_images/`
+- Output images are 26-30GB on disk, ~6GB compressed — too large for git
+
+## File Structure
+
+```
+dexi-os/
+├── build_raspberry_pi_os_ark_cm4.sh      # Build entry point
+├── raspberry_pi_os_ark_cm4.pkr.hcl       # Packer config
+├── base_images/
+│   └── bookwork_jazzy_docker_shrinked.img.gz.xz  # Base image (3.4GB)
+├── resources_raspberry_pi_os/
+│   ├── apt_packages.sh                   # Shared apt package functions
+│   ├── provision_ark_cm4.sh              # CM4 provisioning (main build logic)
+│   ├── provision_pi_os_cm5.sh            # CM5 provisioning
+│   ├── provision_pi_os_pi5.sh            # Pi5 provisioning
+│   ├── setup_code_server.sh              # VS Code server setup
+│   ├── setup_docker_containers.sh        # Docker container setup (CM4/Pi5)
+│   ├── setup_docker_containers_cm5.sh    # Docker container setup (CM5)
+│   ├── dexi-droneblocks.tar              # DroneBlocks web UI container
+│   ├── dexi-node-red.tar                 # Node-RED container
+│   ├── px4-gazebo-headless.tar           # PX4 SITL container (CM5 only)
+│   └── ark_pi6x_default_v1.16.1.px4     # PX4 firmware
+├── .github/workflows/
+│   └── build-ark-cm4.yml                 # CI workflow (self-hosted runner)
+└── dexi_raspberry_pi_os_ark_cm4.img      # Build output (not committed)
+```

--- a/jetson/Dockerfile
+++ b/jetson/Dockerfile
@@ -1,0 +1,133 @@
+# Dexi ROS2 Jazzy for NVIDIA Jetson
+#
+# Builds the Dexi drone stack in a Docker container.
+# Works on any Jetson regardless of host OS (JetPack 5 or 6).
+#
+# Excluded Pi-specific packages: dexi_led, dexi_gpio, camera_ros
+# Camera: uses ros-jazzy-usb-cam instead of camera_ros (libcamera API mismatch)
+#
+# Build: docker build -t dexi-ros2-jazzy .
+# Run:   docker run -it --rm --privileged --network host -v /dev:/dev dexi-ros2-jazzy
+
+FROM ros:jazzy-ros-base
+
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+
+# System packages (mirrors apt_packages.sh from Pi builds)
+RUN apt-get update && apt-get install -y \
+    vim tmux git wget unzip python3-pip python3-vcstool \
+    libi2c-dev libtheora-dev \
+    meson ninja-build pkg-config gcc g++ \
+    libcamera-dev \
+    ros-jazzy-ament-cmake-mypy \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create workspace
+RUN mkdir -p /home/dexi/dexi_ws/src
+WORKDIR /home/dexi/dexi_ws
+
+# Clone dexi_bringup and import all repos
+RUN git clone -b main https://github.com/droneblocks/dexi_bringup src/dexi_bringup \
+    && vcs import --input src/dexi_bringup/dexi.repos src/
+
+# Rosbridge Python dependencies
+RUN pip install --break-system-packages cbor2
+
+# Source ROS2 for all subsequent build steps
+ENV ROS2_SETUP=/opt/ros/jazzy/setup.bash
+
+# Phase 1: Rosbridge
+RUN source $ROS2_SETUP && \
+    colcon build --packages-select rosbridge_test_msgs && \
+    colcon build --packages-select rosbridge_library && \
+    colcon build --packages-select rosapi_msgs && \
+    colcon build --packages-select rosapi && \
+    colcon build --packages-select rosbridge_msgs && \
+    colcon build --packages-select rosbridge_server
+
+# Phase 2: Micro ROS agent
+RUN source $ROS2_SETUP && \
+    colcon build --packages-select micro_ros_msgs && \
+    colcon build --packages-select micro_ros_agent
+
+# Phase 3: DEXI interfaces
+RUN source $ROS2_SETUP && \
+    colcon build --packages-select dexi_interfaces
+
+# Phase 4: PX4 / Flight control (skip lgpio — not needed on Jetson)
+RUN source $ROS2_SETUP && source install/setup.bash && \
+    colcon build --packages-select px4_msgs && \
+    colcon build --packages-select dexi_cpp && \
+    colcon build --packages-select dexi_offboard
+
+# OpenCV needed for vision stack
+RUN apt-get update && apt-get install -y \
+    libopencv-dev libboost-python-dev libboost-dev \
+    ros-jazzy-image-transport \
+    ros-jazzy-camera-info-manager \
+    ros-jazzy-camera-calibration-parsers \
+    ros-jazzy-usb-cam \
+    && rm -rf /var/lib/apt/lists/*
+
+# Phase 5: Vision stack (apriltag + image transport)
+RUN source $ROS2_SETUP && source install/setup.bash && \
+    colcon build --packages-select image_geometry && \
+    colcon build --packages-select cv_bridge && \
+    colcon build --packages-select apriltag && \
+    colcon build --packages-select apriltag_msgs && \
+    colcon build --packages-select topic_tools_interfaces && \
+    colcon build --packages-select topic_tools && \
+    colcon build --packages-select compressed_image_transport && \
+    colcon build --packages-select compressed_depth_image_transport && \
+    colcon build --packages-select theora_image_transport && \
+    colcon build --packages-select zstd_image_transport && \
+    colcon build --packages-select image_transport_plugins
+
+# Phase 6: Camera
+# camera_ros skipped — libcamera MergePolicy API mismatch on Ubuntu 24.04
+# Using ros-jazzy-usb-cam instead for USB cameras on Jetson
+# Build dexi_camera for the calibration file (picamera2 runtime dep won't be used)
+RUN source $ROS2_SETUP && source install/setup.bash && \
+    colcon build --packages-select dexi_camera
+
+# Phase 7: AprilTag detection
+# Remove sources for packages we can't build on Jetson — colcon tries to resolve
+# them even when they're only exec_depends. We use usb-cam instead of camera_ros.
+RUN rm -rf src/camera_ros src/dexi_led src/dexi_gpio
+RUN source $ROS2_SETUP && source install/setup.bash && \
+    colcon build --packages-select apriltag_ros
+
+# Phase 8: YOLO + color detection
+RUN pip install --break-system-packages onnxruntime
+RUN source $ROS2_SETUP && source install/setup.bash && \
+    colcon build --packages-select dexi_yolo && \
+    colcon build --packages-select dexi_color_detection
+
+# Phase 9: Bringup
+RUN source $ROS2_SETUP && source install/setup.bash && \
+    colcon build --packages-select dexi_bringup
+
+# Mavlink-router
+RUN cd /tmp && \
+    git clone https://github.com/mavlink-router/mavlink-router && \
+    cd mavlink-router && \
+    git submodule update --init --recursive && \
+    meson setup build . && \
+    ninja -C build && \
+    ninja -C build install && \
+    cd / && rm -rf /tmp/mavlink-router
+
+# Copy mavlink-router config
+RUN mkdir -p /etc/mavlink-router && \
+    cp /home/dexi/dexi_ws/src/dexi_bringup/config/mavlink-router/ark_cm4_main.conf /etc/mavlink-router/main.conf
+
+# Setup environment in bashrc
+RUN echo "source /opt/ros/jazzy/setup.bash" >> /root/.bashrc && \
+    echo "source /home/dexi/dexi_ws/install/setup.bash" >> /root/.bashrc
+
+# Entrypoint
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bash"]

--- a/jetson/Dockerfile
+++ b/jetson/Dockerfile
@@ -32,7 +32,7 @@ RUN git clone -b main https://github.com/droneblocks/dexi_bringup src/dexi_bring
     && vcs import --input src/dexi_bringup/dexi.repos src/
 
 # Rosbridge Python dependencies
-RUN pip install --break-system-packages cbor2
+RUN pip install --break-system-packages cbor2 tornado twisted pymongo Pillow
 
 # Source ROS2 for all subsequent build steps
 ENV ROS2_SETUP=/opt/ros/jazzy/setup.bash

--- a/jetson/README.md
+++ b/jetson/README.md
@@ -43,11 +43,40 @@ ros2 pkg list | grep dexi
 docker run -it --rm --privileged --network host -v /dev:/dev dexi-ros2-jazzy bash
 
 # Inside container:
-ros2 run usb_cam usb_cam_node_exe --ros-args -p video_device:=/dev/video0 &
+ros2 run usb_cam usb_cam_node_exe --ros-args \
+  -p video_device:=/dev/video0 \
+  -p framerate:=15.0 \
+  -p image_width:=1280 \
+  -p image_height:=720 \
+  -p pixel_format:=mjpeg2rgb \
+  -p brightness:=0 \
+  -p autoexposure:=1 \
+  -p exposure:=200 \
+  -p autofocus:=false \
+  -p focus:=144 \
+  -r /image_raw:=/cam0/image_raw \
+  -r /image_raw/compressed:=/cam0/image_raw/compressed \
+  -r /camera_info:=/cam0/camera_info &
+
 ros2 run apriltag_ros apriltag_node --ros-args \
-  -r image_rect:=/image_raw \
-  -r camera_info:=/camera_info
+  -r image_rect:=/cam0/image_raw \
+  -r camera_info:=/cam0/camera_info \
+  -r /detections:=/apriltag_detections
 ```
+
+#### Arducam USB Camera Settings
+
+The Arducam 12MP UVC camera flickers with default settings. These parameters fix it:
+
+| Parameter | Value | Why |
+|-----------|-------|-----|
+| `autoexposure` | `1` (Manual) | Prevents frame-to-frame exposure variation |
+| `exposure` | `200` | Fixed exposure value (adjust for your lighting) |
+| `brightness` | `0` | Default; usb_cam overrides to 50 which overexposes |
+| `autofocus` | `false` | Prevents focus hunting that disrupts frames |
+| `focus` | `144` | Fixed focus (default value) |
+
+To adjust exposure for different lighting, try values between 50 (bright) and 500 (dim).
 
 ### Full Stack (MAVLink + ROS2)
 

--- a/jetson/README.md
+++ b/jetson/README.md
@@ -1,0 +1,114 @@
+# Dexi on Jetson (Docker)
+
+Runs the Dexi ROS2 stack on NVIDIA Jetson boards via Docker. Tested on Jetson Orin Nano Developer Kit with JetPack 5.1.3 (Ubuntu 20.04).
+
+## Why Docker?
+
+ROS2 Jazzy requires Ubuntu 24.04. The Jetson's host OS (20.04 on JetPack 5, 22.04 on JetPack 6) can't run Jazzy natively. The Docker container runs Ubuntu 24.04 internally, so the host OS version doesn't matter.
+
+## Prerequisites
+
+- NVIDIA Jetson with Docker installed
+- USB camera (e.g., Arducam) for vision tasks
+- ARK Pi6X flight controller connected via USB (for flight)
+
+## Build
+
+```bash
+# Copy jetson/ directory to the Jetson
+scp -r jetson/ user@<jetson-ip>:~/dexi-docker/
+
+# SSH in and build (takes ~30 minutes on Orin Nano)
+ssh user@<jetson-ip>
+cd ~/dexi-docker
+chmod +x build.sh
+./build.sh
+```
+
+The build compiles natively on aarch64 — no QEMU emulation needed, so it's much faster than the Pi image builds.
+
+## Run
+
+```bash
+# Interactive shell
+docker run -it --rm --privileged --network host -v /dev:/dev dexi-ros2-jazzy
+
+# Inside the container:
+ros2 pkg list | grep dexi
+```
+
+### USB Camera + AprilTag Detection
+
+```bash
+docker run -it --rm --privileged --network host -v /dev:/dev dexi-ros2-jazzy bash
+
+# Inside container:
+ros2 run usb_cam usb_cam_node_exe --ros-args -p video_device:=/dev/video0 &
+ros2 run apriltag_ros apriltag_node --ros-args \
+  -r image_rect:=/image_raw \
+  -r camera_info:=/camera_info
+```
+
+### Full Stack (MAVLink + ROS2)
+
+```bash
+docker run -it --rm --privileged --network host -v /dev:/dev dexi-ros2-jazzy bash
+
+# Inside container:
+mavlink-routerd &
+ros2 launch dexi_bringup dexi.launch.py
+```
+
+## Included Packages
+
+| Category | Packages |
+|----------|----------|
+| AprilTag | `apriltag`, `apriltag_ros`, `apriltag_msgs` |
+| Flight Control | `px4_msgs`, `dexi_cpp`, `dexi_offboard`, `dexi_interfaces` |
+| Camera | `usb_cam` (V4L2), `dexi_camera` (calibration files) |
+| Vision | `cv_bridge`, `image_transport`, all transport plugins |
+| AI/ML | `dexi_yolo`, `dexi_color_detection` |
+| Comms | `rosbridge_server`, `micro_ros_agent` |
+| MAVLink | `mavlink-routerd` |
+| Bringup | `dexi_bringup` |
+
+## Excluded Packages (Pi-specific)
+
+| Package | Reason |
+|---------|--------|
+| `dexi_led` | NeoPixel/pi5neo GPIO hardware |
+| `dexi_gpio` | lgpio, Pi-specific |
+| `camera_ros` | libcamera `MergePolicy` API mismatch in Ubuntu 24.04; replaced by `usb_cam` |
+
+## Upgrading to JetPack 6 / Ubuntu 22.04
+
+If you reflash the Jetson to JetPack 6.x (Ubuntu 22.04), you have two options:
+
+### Option A: Keep using Docker (recommended for Jazzy)
+This Dockerfile works unchanged on any host OS. The container always runs Ubuntu 24.04 internally. No changes needed.
+
+### Option B: Native ROS2 Humble
+Ubuntu 22.04 supports ROS2 Humble natively. You would:
+1. `sudo apt install ros-humble-desktop`
+2. Clone and build the dexi workspace, pinning repos to `humble` branches where available
+3. Same package exclusions apply (no dexi_led/gpio)
+
+Note: Humble is EOL May 2027. Jazzy (in Docker) is supported until May 2029.
+
+### Option C: Native ROS2 Jazzy from source on 22.04
+Possible but not recommended — many Jazzy deps target Noble (24.04). Docker is easier.
+
+## Architecture Notes
+
+The camera pipeline on Jetson differs from the Pi:
+
+```
+Pi:       Arducam → dexi_camera (picamera2) → image topics → apriltag_ros
+Jetson:   Arducam → usb_cam (V4L2)          → image topics → apriltag_ros
+```
+
+The downstream pipeline (apriltag_ros, dexi_offboard, etc.) is identical. Topic names may need remapping — `usb_cam` publishes to `/image_raw` while `camera_ros` uses `/camera/image_raw`.
+
+## Image Size
+
+The built Docker image is ~3.8GB. Ensure the Jetson has sufficient disk space (the Orin Nano Dev Kit has 116GB eMMC).

--- a/jetson/README.md
+++ b/jetson/README.md
@@ -29,8 +29,24 @@ The build compiles natively on aarch64 — no QEMU emulation needed, so it's muc
 
 ## Run
 
+### Quick Start (Full Stack)
+
 ```bash
-# Interactive shell
+# Start everything: camera, rosbridge, apriltag, yolo, web UI
+sudo ./start.sh
+
+# Without YOLO
+sudo ./start.sh --no-yolo
+
+# Without AprilTag
+sudo ./start.sh --no-apriltag
+```
+
+Then open `http://<jetson-ip>:3000` in your browser.
+
+### Interactive Shell
+
+```bash
 docker run -it --rm --privileged --network host -v /dev:/dev dexi-ros2-jazzy
 
 # Inside the container:

--- a/jetson/build.sh
+++ b/jetson/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Build the Dexi ROS2 Jazzy Docker image for NVIDIA Jetson
+#
+# Builds natively on aarch64 — no QEMU emulation needed.
+# Takes ~30 minutes on Jetson Orin Nano.
+#
+# Usage:
+#   ./build.sh              # build with default tag
+#   ./build.sh v1.0         # build with custom tag
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGE_NAME="dexi-ros2-jazzy"
+TAG="${1:-latest}"
+
+echo "Building ${IMAGE_NAME}:${TAG}..."
+echo "This will take a while (ROS2 workspace compilation)."
+echo ""
+
+docker build -t "${IMAGE_NAME}:${TAG}" "${SCRIPT_DIR}"
+
+echo ""
+echo "Build complete: ${IMAGE_NAME}:${TAG} ($(docker image inspect ${IMAGE_NAME}:${TAG} --format='{{.Size}}' | numfmt --to=iec 2>/dev/null || echo 'check with docker images'))"
+echo ""
+echo "Run with:"
+echo "  docker run -it --rm --privileged --network host -v /dev:/dev ${IMAGE_NAME}:${TAG}"

--- a/jetson/entrypoint.sh
+++ b/jetson/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+source /opt/ros/jazzy/setup.bash
+source /home/dexi/dexi_ws/install/setup.bash
+exec "$@"

--- a/jetson/start.sh
+++ b/jetson/start.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Start the full Dexi stack on Jetson Orin Nano
+#
+# Usage:
+#   ./start.sh              # Start all services
+#   ./start.sh --no-yolo    # Start without YOLO
+#   ./start.sh --no-apriltag # Start without AprilTag
+
+set -e
+
+IMAGE_NAME="dexi-ros2-jazzy"
+ROS2_CONTAINER="dexi-ros2"
+WEB_CONTAINER="dexi-web"
+
+# Parse args
+ENABLE_YOLO=true
+ENABLE_APRILTAG=true
+for arg in "$@"; do
+    case $arg in
+        --no-yolo) ENABLE_YOLO=false ;;
+        --no-apriltag) ENABLE_APRILTAG=false ;;
+    esac
+done
+
+# Stop any existing containers
+echo "Stopping existing containers..."
+docker rm -f ${ROS2_CONTAINER} ${WEB_CONTAINER} 2>/dev/null || true
+sleep 2
+
+# Build the ROS2 launch command
+LAUNCH_CMD="
+# Rosbridge
+ros2 launch rosbridge_server rosbridge_websocket_launch.xml &
+sleep 5
+
+# Camera (Arducam 12MP UVC with anti-flicker settings)
+ros2 run usb_cam usb_cam_node_exe --ros-args \\
+  -p video_device:=/dev/video0 \\
+  -p framerate:=15.0 \\
+  -p image_width:=1280 \\
+  -p image_height:=720 \\
+  -p pixel_format:=mjpeg2rgb \\
+  -p brightness:=0 \\
+  -p autoexposure:=1 \\
+  -p exposure:=200 \\
+  -p autofocus:=false \\
+  -p focus:=144 \\
+  -r /image_raw:=/cam0/image_raw \\
+  -r /image_raw/compressed:=/cam0/image_raw/compressed \\
+  -r /camera_info:=/cam0/camera_info &
+sleep 3
+"
+
+if [ "$ENABLE_APRILTAG" = true ]; then
+    LAUNCH_CMD+="
+# AprilTag detection
+ros2 run apriltag_ros apriltag_node --ros-args \\
+  -r image_rect:=/cam0/image_raw \\
+  -r camera_info:=/cam0/camera_info \\
+  -r /detections:=/apriltag_detections &
+sleep 2
+"
+fi
+
+if [ "$ENABLE_YOLO" = true ]; then
+    LAUNCH_CMD+="
+# YOLO detection (CPU, custom model: car/motorcycle/truck/bird/cat/dog)
+ros2 launch dexi_yolo yolo_onnx_launch.py num_threads:=4 detection_frequency:=2.0 &
+"
+fi
+
+LAUNCH_CMD+="
+wait
+"
+
+# Start ROS2 container
+echo "Starting ROS2 container..."
+docker run -d --rm --privileged --network host \
+    -v /dev:/dev \
+    --name ${ROS2_CONTAINER} \
+    ${IMAGE_NAME} bash -c "${LAUNCH_CMD}"
+
+# Start web container
+echo "Starting web container..."
+docker run -d --rm --network host \
+    --name ${WEB_CONTAINER} \
+    droneblocks/dexi-droneblocks:latest
+
+echo ""
+echo "Waiting for services to start..."
+sleep 15
+
+# Verify
+echo ""
+echo "=== Container Status ==="
+docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Image}}"
+echo ""
+echo "=== ROS2 Topics ==="
+docker exec ${ROS2_CONTAINER} bash -c "source /opt/ros/jazzy/setup.bash && source /home/dexi/dexi_ws/install/setup.bash && ros2 topic list" 2>/dev/null
+echo ""
+echo "Web UI: http://$(hostname -I | awk '{print $1}'):3000"
+echo "Rosbridge: ws://$(hostname -I | awk '{print $1}'):9090"


### PR DESCRIPTION
## Summary
- Adds `jetson/` directory with Dockerfile, build script, and entrypoint to run the Dexi ROS2 Jazzy stack on NVIDIA Jetson boards via Docker
- Tested and built successfully on Jetson Orin Nano Dev Kit (JetPack 5.1.3, Ubuntu 20.04)
- Adds CLAUDE.md with full build system documentation including the new Jetson platform

## What's included
All flight, vision, and AI packages: `apriltag_ros`, `dexi_offboard`, `dexi_yolo`, `micro_ros_agent`, `rosbridge`, `mavlink-router`, `usb_cam`, `px4_msgs`, `dexi_bringup`, and more.

## What's excluded (Pi-specific)
- `dexi_led` — NeoPixel/pi5neo GPIO hardware
- `dexi_gpio` — lgpio, Pi-specific
- `camera_ros` — libcamera API mismatch on Ubuntu 24.04; replaced by `usb_cam`

## Test plan
- [x] Docker image builds successfully on Jetson Orin Nano (~30 min native aarch64 build)
- [x] All 16 expected ROS2 packages install and list correctly
- [x] `apriltag_ros`, `usb_cam`, `mavlink-routerd` executables verified
- [ ] End-to-end test with USB camera + AprilTag detection
- [ ] End-to-end test with flight controller + dexi_bringup launch