### PR TITLE
Clean up CM5 provision: pin dexi_bringup to main, drop obsolete lg library build

### DIFF
--- a/resources_raspberry_pi_os/provision_pi_os_cm5.sh
+++ b/resources_raspberry_pi_os/provision_pi_os_cm5.sh
@@ -38,7 +38,7 @@ rm -rf /home/dexi/dexi_ws/*
 mkdir -p /home/dexi/dexi_ws/src
 
 cd /home/dexi/dexi_ws
-git clone http://github.com/droneblocks/dexi_bringup /home/dexi/dexi_ws/src/dexi_bringup
+git clone -b main https://github.com/droneblocks/dexi_bringup /home/dexi/dexi_ws/src/dexi_bringup
 vcs import --input /home/dexi/dexi_ws/src/dexi_bringup/dexi.repos /home/dexi/dexi_ws/src/
 source /home/dexi/ros2_jazzy/install/setup.bash
 
@@ -70,18 +70,6 @@ colcon build --packages-select dexi_interfaces
 # DEXI LED
 pip install --break-system-packages pi5neo
 colcon build --packages-select dexi_led
-
-# Dependencies for DEXI CPP
-cd /home/dexi
-wget http://abyz.me.uk/lg/lg.zip
-unzip lg.zip
-cd lg
-make
-make install
-cd ..
-rm -rf lg.zip
-rm -rf lg
-cd /home/dexi/dexi_ws
 
 # DEXI CPP
 colcon build --packages-select px4_msgs


### PR DESCRIPTION
## Summary

Two small cleanups to \`resources_raspberry_pi_os/provision_pi_os_cm5.sh\`:

1. **Pin dexi_bringup clone to \`-b main\` explicitly** — previously relied on the default branch. Matches the style used in \`provision_ark_cm4.sh\` after commit \`404b92b\`.
2. **Remove obsolete \`lg\` C library build** — the provision script was downloading and compiling [abyz.me.uk/lg/lg.zip](http://abyz.me.uk/lg/lg.zip) before building \`dexi_cpp\`. \`dexi_cpp\` no longer references lg/lgpio anywhere; its CMakeLists only links \`stdc++fs\` and \`i2c\`. Removing this step shaves ~1-2 minutes off the build.

## Verified

Built the CM5 image from this branch's provision script earlier this session:
- 8m41s clean build
- 30 packages colcon-built successfully (including \`dexi_cpp\` in 4.63s with no linker errors — confirming \`lg\` truly isn't needed)
- Image mount-inspected: dexi_bringup on \`refs/heads/main\`, rosbridge pinned at \`a8870f6\`, all services enabled, 20.9 G used of 29 G root

## Test plan

- [x] CM5 image builds cleanly without the \`lg\` step
- [x] \`dexi_cpp\` colcon build succeeds
- [x] \`dexi_bringup\` in \`src/\` on \`main\` after vcs import
- [ ] Flash to CM5 hardware and confirm dexi.service comes up (pending — CM4 took priority this cycle)