### PR TITLE
ARK CM4: install pigpio for servo PWM + pin dexi_bringup to main

### DIFF
--- a/resources_raspberry_pi_os/apt_packages.sh
+++ b/resources_raspberry_pi_os/apt_packages.sh
@@ -21,3 +21,10 @@ install_camera_packages() {
     apt install -y libcamera-dev >/dev/null 2>&1
     log "Camera packages installed successfully"
 }
+
+# Pigpio (CM4 servo PWM via DMA daemon)
+install_pigpio_packages() {
+    log "Installing pigpio packages..."
+    apt install -y pigpio python3-pigpio >/dev/null 2>&1
+    log "Pigpio packages installed successfully"
+}

--- a/resources_raspberry_pi_os/provision_ark_cm4.sh
+++ b/resources_raspberry_pi_os/provision_ark_cm4.sh
@@ -29,6 +29,8 @@ echo 'nameserver 1.1.1.1' > /run/systemd/resolve/stub-resolv.conf
 log "Updating system packages..."
 apt-get update -y >/dev/null 2>&1 && apt-get upgrade -y >/dev/null 2>&1
 install_common_packages
+install_pigpio_packages
+systemctl enable pigpiod
 log "System packages updated successfully"
 #######################################################################################
 

--- a/resources_raspberry_pi_os/provision_ark_cm4.sh
+++ b/resources_raspberry_pi_os/provision_ark_cm4.sh
@@ -38,7 +38,7 @@ rm -rf /home/dexi/dexi_ws/*
 mkdir -p /home/dexi/dexi_ws/src
 
 cd /home/dexi/dexi_ws
-git clone -b feature/dexi-platform-params https://github.com/droneblocks/dexi_bringup /home/dexi/dexi_ws/src/dexi_bringup
+git clone -b main https://github.com/droneblocks/dexi_bringup /home/dexi/dexi_ws/src/dexi_bringup
 vcs import --input /home/dexi/dexi_ws/src/dexi_bringup/dexi.repos /home/dexi/dexi_ws/src/
 source /home/dexi/ros2_jazzy/install/setup.bash
 


### PR DESCRIPTION
## Summary

Two changes to make the ARK CM4 image support the new pigpio-backed servo_pwm_service:

1. **Install pigpio** via a new \`install_pigpio_packages()\` function in \`apt_packages.sh\`, called from \`provision_ark_cm4.sh\`. Enables the \`pigpiod\` service at build time so it auto-starts on first boot.
2. **Pin dexi_bringup clone to \`-b main\`** — previously on the since-merged \`feature/dexi-platform-params\` branch. Aligns with the CM5 PR.

## Dependency chain

This closes the loop on servo support for ARK CM4:

| Repo | PR | What it did |
|---|---|---|
| \`dexi_gpio\` | [#2](https://github.com/DroneBlocks/dexi_gpio/pull/2) | Added \`servo_pwm_service\` (pigpio backend, pins [21,22]) — MERGED |
| \`dexi_bringup\` | [#17](https://github.com/DroneBlocks/dexi_bringup/pull/17) | Wired servo_pwm_service into ark_cm4 bringup with gpio/servos mutex — MERGED |
| \`dexi-os\` | this PR | Installs pigpio on the image so the service can actually run |

Without this PR, a customer flashing the image would see \`servo_pwm_service\` fail to start with \`pigpiod not reachable\` and need to manually \`sudo apt install pigpio python3-pigpio && sudo systemctl enable --now pigpiod\`.

CM5/Pi5 are unaffected: the new \`install_pigpio_packages\` function is only called from \`provision_ark_cm4.sh\`.

## Verified

Built an ARK CM4 image from this branch earlier this session:

- 9m9s clean build, no errors
- Mount-inspected: \`/usr/bin/pigpiod\` present, \`pigpiod.service\` enabled (symlink in \`multi-user.target.wants/\`), \`python3-pigpio\` in dist-packages
- Flashed to drone, post-boot: \`pigpiod\` active, \`servo_pwm_service\` running, \`/dexi/servo_control\` registered
- Drove a hobby servo end-to-end via three paths: direct \`ros2 service call\`, standalone Python sweep (\`servo_sweep_standalone.py\`), and a Node-RED flow over rosbridge

## Known caveat (not addressed here)

The default \`~/.dexi-config.yaml\` on a fresh CM4 flash has both \`gpio.enabled: true\` and \`servo.enabled: true\`. The mutex from dexi_bringup PR #17 gives priority to gpio in that case, so servos are suppressed by default. Customers wiring servos to J25 need to set \`gpio.enabled: false\` manually. Tracked as a follow-up: either default \`servo.enabled: false\` on CM4 (bypassed by install.bash behavior today) or a platform-aware install.bash.

## Test plan

- [x] ARK CM4 image builds cleanly with new function and systemctl enable
- [x] pigpiod active + enabled on first boot
- [x] servo_pwm_service starts without errors
- [x] Servo physically driven from ros2 service call
- [x] Servo physically driven from standalone Python (pigpio direct)
- [x] Servo physically driven from Node-RED via rosbridge
- [ ] CM5 image still builds cleanly (function unused on CM5 — should no-op)
- [ ] Pi5 image still builds cleanly (function unused on Pi5 — should no-op)