### PR TITLE
Remove obsolete lg C library build from ARK CM4 provision

### DIFF
--- a/resources_raspberry_pi_os/provision_ark_cm4.sh
+++ b/resources_raspberry_pi_os/provision_ark_cm4.sh
@@ -85,18 +85,6 @@ colcon build --packages-select dexi_led
 # DEXI GPIO
 colcon build --packages-select dexi_gpio
 
-# Dependencies for DEXI CPP
-cd /home/dexi
-wget https://abyz.me.uk/lg/lg.zip
-unzip lg.zip
-cd lg
-make
-make install
-cd ..
-rm -rf lg.zip
-rm -rf lg
-cd /home/dexi/dexi_ws
-
 # DEXI CPP
 colcon build --packages-select px4_msgs
 colcon build --packages-select dexi_cpp


### PR DESCRIPTION
## Summary

Follow-up to [#27](https://github.com/DroneBlocks/dexi-os/pull/27). Removes the \`lg\` C library build (abyz.me.uk/lg/lg.zip) from \`provision_ark_cm4.sh\`. Nothing in the image actually depends on it.

## Evidence

- \`dexi_cpp/CMakeLists.txt\` \`target_link_libraries\` entries are only \`stdc++fs\` and \`i2c\`. No \`-llgpio\`, no \`-llg\`.
- Source grep of \`dexi_cpp/src/\` finds no \`#include <lgpio.h>\` or \`<rgpio.h>\`. (Grep hits on the substring "lg" were false positives from \`algorithm\`.)
- \`dexi_gpio\`'s Python nodes: \`gpio_reader\` and \`gpio_writer_service\` use \`RPi.GPIO\`; \`servo_pwm_service\` uses \`pigpio\` (handled by PR #27). None import \`lgpio\`.

## Matches the CM5 cleanup

Same rationale as [#26](https://github.com/DroneBlocks/dexi-os/pull/26), which removes the identical \`lg\` block from the CM5 provision script.

## Impact

- Shaves ~60-90s off the CM4 build
- Removes a runtime dependency on an unmirrored third-party site (abyz.me.uk) — build becomes more reliable
- No functional change to the image

## Test plan

- [ ] Build ARK CM4 image with this branch
- [ ] Confirm \`dexi_cpp\` still builds cleanly (no linker errors)
- [ ] Confirm servo_pwm_service still moves a servo (verifies GPIO path is unaffected)