### PR TITLE
Build dexi_apriltag during image provisioning

### DIFF
--- a/resources_raspberry_pi_os/provision.sh
+++ b/resources_raspberry_pi_os/provision.sh
@@ -161,6 +161,9 @@ colcon build --packages-select dexi_color_detection
 # DEXI bringup (the launch package and start.bash)
 colcon build --packages-select dexi_bringup
 
+# DEXI AprilTag corridor / precision-landing nodes (apriltag_odometry, tag_hop, precision_landing)
+colcon build --packages-select dexi_apriltag
+
 # Install DEXI service
 cd /home/dexi/dexi_ws/src/dexi_bringup/scripts
 ./install.bash


### PR DESCRIPTION
## Summary

`dexi_apriltag` is already cloned via `dexi.repos` but was never compiled during image build. Adds a single `colcon build --packages-select dexi_apriltag` line to provision.sh so the package's nodes ship in fresh images.

## What this enables

After flashing a fresh image, the following are available without any post-flash build step:
- `ros2 run dexi_apriltag tag_hop.py` — corridor navigation
- `ros2 run dexi_apriltag apriltag_odometry_node` — vision-based EKF odometry
- `ros2 run dexi_apriltag precision_landing.py` — autonomous tag landing

## Why this was missing

`dexi_apriltag` is in `dexi.repos`, so the source clones during provisioning. But `provision.sh` builds packages with explicit `colcon build --packages-select` lines, and `dexi_apriltag` was never added to that list. Result: source present at `/home/dexi/dexi_ws/src/dexi_apriltag/` but no install — the package's binaries and Python scripts aren't visible to `ros2 run`.

## Placement

Right after `dexi_bringup` (line 162). Dependencies are all built earlier in the script:
- `dexi_interfaces` — line 88
- `apriltag_msgs`, `apriltag_ros` — line 144
- `px4_msgs` — line 123
- `cv_bridge` — line 129

## Test plan

- [ ] Run GHA build for ARK CM4 target
- [ ] Flash, boot
- [ ] `ls /home/dexi/dexi_ws/install/dexi_apriltag/lib/dexi_apriltag/` should show `apriltag_odometry_node`, `apriltag_visualizer`, `apriltag_odometry.py`, `precision_landing.py`, `corridor_navigation.py`, `tag_yaw_track.py`, `tag_hop.py`
- [ ] `ros2 run dexi_apriltag tag_hop.py --ros-args -p sequence:='[0]'` initializes without errors

## Out of scope

- Configuring `apriltag_node`'s `tag.ids` in `dexi_bringup` — that's tag-layout-specific and lives in the bringup repo. Users either edit the bringup launch post-flash or pass tag IDs as runtime overrides.
- Auto-starting `apriltag_odometry` — kept manual since its `tag_map` is testbed-specific.