### PR TITLE
Use dexi-<MAC> hostname/SSID, drop duplicate logic from first_boot.sh

### DIFF
--- a/resources_raspberry_pi_os/first_boot.sh
+++ b/resources_raspberry_pi_os/first_boot.sh
@@ -1,20 +1,10 @@
 #!/bin/bash
 
-#determine the SSID to configure
-FULL_MAC=$(cat /sys/class/net/wlan0/address)
-PARTIAL_MAC=$(echo $FULL_MAC | awk -F: '{print $(NF-1)$NF}')
-DEXI_SSID="dexi_$PARTIAL_MAC"
-
-# Setup hostname
-hostnamectl hostname $DEXI_SSID
-# Doing it this way because the underscore gets stripped
-echo "127.0.0.1 $(hostnamectl hostname)" >> /etc/hosts
+# Hostname is set by dexi-set-hostname.service (installed by dexi-networking).
+# Hotspot is set up by dexi-hotspot-setup.service (installed by provision.sh).
 
 # Setup DEXI ROS2 launch file to run on boot
 # /home/dexi/dexi_ws/src/dexi/scripts/install.bash
-
-#setup the wifi stuff but use placeholders for first boot
-/home/dexi/wifi_utilities/setup_wlan_and_AP_modes.sh -d -s XXXXXXXX -p XXXXXXXX  -a $DEXI_SSID -r droneblocks
 
 # Change dexi directory permissions
 chown -R dexi:dexi /home/dexi

--- a/resources_raspberry_pi_os/provision.sh
+++ b/resources_raspberry_pi_os/provision.sh
@@ -244,7 +244,7 @@ cat > /usr/local/bin/dexi-hotspot-setup.sh << 'EOF'
 #!/bin/bash
 sleep 10
 PARTIAL_MAC=$(cat /sys/class/net/wlan0/address | awk -F: '{print $(NF-1)$NF}')
-DEXI_SSID="dexi_$PARTIAL_MAC"
+DEXI_SSID="dexi-$PARTIAL_MAC"
 /usr/local/bin/dexi/create_hotspot.sh "$DEXI_SSID" "droneblocks"
 systemctl disable dexi-hotspot-setup.service
 EOF


### PR DESCRIPTION
## Summary
- Drop hostname-setting logic from `resources_raspberry_pi_os/first_boot.sh`. It is now handled by `dexi-set-hostname.service` shipped with `dexi-networking` ([PR #2](https://github.com/DroneBlocks/dexi-networking/pull/2)).
- Drop the dead `wifi_utilities/setup_wlan_and_AP_modes.sh` call from `first_boot.sh`. The active Pi OS provision script no longer installs that path (replaced by `dexi-networking`'s nmcli scripts), so the call has been silently failing.
- Change hotspot SSID separator from underscore to hyphen in `resources_raspberry_pi_os/provision.sh`, so SSID and hostname match (`dexi-a4b2` in both places).

## Why
Two goals:

1. **Make the router stop showing the drone as `raspberrypi`.** Today the rename only happens via `first_boot.sh` and only on the full dexi-os image. Moving the rename into `dexi-networking` makes it travel with the package.

2. **One identity string, everywhere.** Hostname, hotspot SSID, mDNS name, router DHCP entry — all the same `dexi-<mac>` form. Hyphen instead of underscore so it's a valid DNS label and `dexi-a4b2.local` resolves cleanly. The first-boot hotspot SSID then doubles as how a student learns their drone's name; they use the same string when pinging it from a router.

## Notes for review
- This PR depends on `dexi-networking` PR #2 landing first (otherwise no hostname gets set at all on next image build).
- I noticed `provision_test_docker.sh`, `provision_pi_os_lite_ros2.sh`, and `resources_pi_zero_2w/provision_pi_zero_2w.sh` exist locally but aren't tracked in git on this branch, so they're not part of this PR. They have the same `DEXI_SSID="dexi_$PARTIAL_MAC"` pattern and will need the same separator bump when they land — happy to follow up once they're committed.
- Existing fielded drones will rename from `dexi_xxxx` → `dexi-xxxx` on their next image flash. Worth a release-notes line.

## Test plan
- [ ] Build the Pi OS image, flash a Pi, confirm hostname is `dexi-<mac>` (not `raspberrypi` or `dexi_<mac>`).
- [ ] Confirm hotspot SSID is `dexi-<mac>` and matches the hostname.
- [ ] Confirm `ping dexi-<mac>.local` works from a Mac on the same LAN as the router after the drone joins it.
- [ ] Confirm `/etc/hosts` has a `127.0.1.1 dexi-<mac>` entry and `sudo` does not warn about hostname resolution.
- [ ] Confirm there are no `wifi_utilities` "no such file" errors in the first-boot log.