### PR TITLE
Preinstall ms-python.python in code-server provisioning

### DIFF
--- a/resources_raspberry_pi_os/setup_code_server.sh
+++ b/resources_raspberry_pi_os/setup_code_server.sh
@@ -35,6 +35,14 @@ cat > /home/dexi/.local/share/code-server/User/settings.json << 'EOF'
 }
 EOF
 
+# Install Python extension (provides the Run button + language features).
+# Pulls in ms-python.debugpy and ms-python.vscode-python-envs as transitive deps.
+log "Installing ms-python.python extension..."
+sudo -u dexi HOME=/home/dexi code-server --install-extension ms-python.python
+
+# Make sure code-server's data dirs are owned by the dexi user
+chown -R dexi:dexi /home/dexi/.config/code-server /home/dexi/.local/share/code-server
+
 # Create systemd service file
 cat > /etc/systemd/system/code-server.service << 'EOF'
 [Unit]


### PR DESCRIPTION
## Summary

Install `ms-python.python` from Open VSX in `resources_raspberry_pi_os/setup_code_server.sh` so freshly-built dexi-os images launch code-server with the **Run Python File** button (and language features) available out of the box.

## Why

`setup_code_server.sh` installs code-server but never installs any extensions. On a fresh image, `code-server --list-extensions` returns empty — no Run button, no completions, no debugger. Students get a blank editor with no obvious way to execute the lesson script they just wrote.

The DEXI sim's code-server Dockerfile (`dexi-sim-ftw/code-server/Dockerfile`) has been doing this exact install for a while:

```dockerfile
RUN code-server --install-extension ms-python.python
```

This PR brings the dexi-os image to parity with the sim's behavior.

## What the install pulls in

From the live test on a running drone:

| Extension | Version | Role |
|---|---|---|
| `ms-python.python` | 2026.4.0 | Run button, language server, REPL |
| `ms-python.debugpy` | 2026.6.0 | Debugger (transitive) |
| `ms-python.vscode-python-envs` | 1.30.0 | Env management (transitive) |

All three install with one CLI call — Open VSX resolves the transitive deps automatically.

## The change

```bash
# Install Python extension (provides the Run button + language features).
# Pulls in ms-python.debugpy and ms-python.vscode-python-envs as transitive deps.
log "Installing ms-python.python extension..."
sudo -u dexi HOME=/home/dexi code-server --install-extension ms-python.python

# Make sure code-server's data dirs are owned by the dexi user
chown -R dexi:dexi /home/dexi/.config/code-server /home/dexi/.local/share/code-server
```

Inserted between the `settings.json` block and the systemd service block. The `sudo -u dexi HOME=/home/dexi` is the standard pattern for landing extensions in `/home/dexi/.local/share/code-server/extensions/` (the path already declared in `config.yaml`). The trailing `chown -R` is belt-and-suspenders for ownership of code-server's data dirs after the earlier root-side `mkdir`/`cat` calls.

## Test plan

- [x] Apply the install on a live dexi-os drone via SSH; reload code-server; confirm Run button appears on `.py` files
- [ ] Build a fresh image from this branch; flash + boot; verify `code-server --list-extensions` returns the three extensions on first boot
- [ ] Open a `.py` file in the freshly-imaged drone; confirm Run button is present, debugger works
- [ ] `bash -n resources_raspberry_pi_os/setup_code_server.sh` ✓ (already verified)

## Rollback

Revert the 8-line addition. Extensions disappear on the next image build; deployed images can be cleaned with `code-server --uninstall-extension ms-python.python ms-python.debugpy ms-python.vscode-python-envs`.