### PR TITLE
Bake mavlink2rest 1.0.2 alongside mavlink-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Custom Raspberry Pi OS images for DEXI drone systems with pre-configured ROS2, n
   - CM4: CSI camera with libcamera
   - Pi5: USB camera support
 - **MAVLink Router**: Drone communication protocol routing
+- **mavlink2rest**: REST/WebSocket bridge on TCP `:8088` (browser GCS such as `px4-web-configurator` over LAN/hotspot; pinned to upstream 1.0.2)
 
 ### Networking & Connectivity
 - **WiFi Hotspot**: Auto-configured with MAC-based SSID (`dexi_XXXX`)

--- a/resources_raspberry_pi_os/provision.sh
+++ b/resources_raspberry_pi_os/provision.sh
@@ -197,6 +197,71 @@ RestartSec=5
 EOF
 ########################################################################################
 
+#################################### mavlink2rest ####################################
+# Build mavlink2rest (REST/WebSocket bridge for MAVLink) from source in the
+# chroot. Upstream ships no prebuilt binaries, so source build is the only
+# option. Pinned to SHA 237c8899c29f84d28af02d928263558a31017f3e (tag 1.0.2)
+# for parity with the dexi-sim-ftw sim build.
+#
+# Resulting binary lives at /usr/local/bin/mavlink2rest. The toolchain
+# (rustup + cargo + ~/target) is removed at the end of this section to keep
+# the flashed image small — without cleanup the chroot would balloon ~1.5 GB.
+log "Building mavlink2rest from source (Rust)..."
+MAVLINK2REST_SHA=237c8899c29f84d28af02d928263558a31017f3e
+
+# Install rustup non-interactively into /opt so we can wipe it cleanly later.
+# Debian Bookworm's stock rustc (1.63) is too old for current mavlink2rest crates.
+quiet_run curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/rustup-init.sh
+chmod +x /tmp/rustup-init.sh
+RUSTUP_HOME=/opt/rustup CARGO_HOME=/opt/cargo /tmp/rustup-init.sh \
+    -y --default-toolchain stable --profile minimal --no-modify-path >/dev/null 2>&1
+
+export PATH="/opt/cargo/bin:$PATH"
+export RUSTUP_HOME=/opt/rustup
+export CARGO_HOME=/opt/cargo
+
+cd /tmp
+git clone https://github.com/mavlink/mavlink2rest.git mavlink2rest
+cd mavlink2rest
+git checkout "$MAVLINK2REST_SHA"
+cargo build --release
+strip target/release/mavlink2rest
+install -m 0755 target/release/mavlink2rest /usr/local/bin/mavlink2rest
+
+# Tear down toolchain + source — saves ~1.5 GB of chroot bloat.
+cd /home/dexi
+rm -rf /tmp/mavlink2rest /tmp/rustup-init.sh /opt/rustup /opt/cargo /root/.cargo /root/.rustup
+unset CARGO_HOME RUSTUP_HOME
+
+# Systemd unit. Runs as root (matches mavlink-router today). Connects via
+# udpout to 127.0.0.1:14770 — the dedicated loopback endpoint added in the
+# companion dexi_bringup PR. REST + WS surface is 0.0.0.0:8088 (no auth on
+# v0.20; relies on WPA on the dexi_<MAC> hotspot). After=mavlink-router so
+# the router endpoint is reachable when we come up.
+cat > /etc/systemd/system/mavlink2rest.service << 'EOF'
+[Unit]
+Description=mavlink2rest - REST/WebSocket bridge for MAVLink, exposes drone telemetry to browser GCS over LAN/Wi-Fi/AP
+Documentation=https://github.com/mavlink/mavlink2rest
+After=mavlink-router.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/local/bin/mavlink2rest --connect=udpout:127.0.0.1:14770 --server=0.0.0.0:8088
+Restart=on-failure
+RestartSec=2
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl enable mavlink2rest.service
+log "mavlink2rest installed at /usr/local/bin/mavlink2rest (SHA $MAVLINK2REST_SHA), service enabled"
+########################################################################################
+
 #################################### ARK companion + PX4 firmware ####################################
 # Pi 5 has no flight controller attached, skip both
 if [ "$TARGET" = "cm5" ] || [ "$TARGET" = "ark_cm4" ]; then


### PR DESCRIPTION
## Summary

Adds **mavlink2rest** (REST/WebSocket bridge for MAVLink) to the dexi-os image so every DEXI drone exposes a browser-reachable endpoint on TCP **8088**. Pinned to upstream SHA `237c8899c29f84d28af02d928263558a31017f3e` (release tag `1.0.2`) for parity with the sim build.

## Topology

```
FC (UART) ─► mavlink-router (existing)
                ├─► UDP 14540  (MAVSDK — existing)
                ├─► UDP 14550  (GCS / pymavlink — existing)
                └─► UDP 14770  (mavlink2rest feed — new, from DroneBlocks/dexi_bringup#23)
                       │
                       ▼  udpout 127.0.0.1:14770
                  mavlink2rest (NEW service)
                       │
                       └─► REST + WebSocket on :8088 ◄── browser GCS over LAN / dexi_<MAC> hotspot
```

## What's in this PR

- **`provision.sh`** (+65 lines, after the existing mavlink-router build at ~line 198): clone upstream mavlink2rest, `git checkout 237c8899…`, `cargo build --release`, install stripped binary to `/usr/local/bin/mavlink2rest`. Toolchain (`/opt/rustup`, `/opt/cargo`, `/root/.cargo`, `/root/.rustup`, `/tmp/mavlink2rest`) is torn down before image finalization so the ~1.5 GB build footprint doesn't end up in the image.
- **Systemd unit** (emitted via in-script heredoc, matching the existing `mavlink-router.service.d/override.conf` and `dexi-hotspot-setup.service` patterns): runs as root, `After=mavlink-router.service`, `Restart=on-failure`. Enabled via `systemctl enable mavlink2rest.service` at the same point in `provision.sh` where mavlink-router is enabled.
- **README** (+1 bullet under Pre-installed Software).

## Image impact

- Disk: ~10–12 MB added (stripped ARM64 binary + tiny unit file).
- Build time: +3–5 min on the Mac mini builder, +10–15 min on the Pi 5 builder (Rust compile dominates).
- No `.pkr.hcl` or `.github/workflows/build-image.yml` change needed — the provisioner already stages the whole `resources_raspberry_pi_os/` dir.

## Companion PRs

- `DroneBlocks/dexi_bringup#23` — adds the `[UdpEndpoint mavlink2rest]` block on port 14770 to `main.conf` and `ark_cm4_main.conf`. **This PR depends on it landing first**; without that endpoint, `mavlink2rest` boots fine but `/v1/mavlink/vehicles` stays empty.
- `DroneBlocks/dexi-sim-ftw` (separate PR pending) — same SHA pin + same port `14770` for parity with the sim.

## Per-platform notes

Covers Pi 4 / Pi 5 / CM5 / ARK CM4 (all share `resources_raspberry_pi_os/provision.sh`). **Jetson Orin Nano is excluded** — it ships dexi-os via a Docker container on L4T (`feature/jetson-docker-support`), bypassing the packer/provision flow. Track as a follow-up.

On Pi 5 the binary is present but unused (no FC attached) — that's the correct behavior.

## Network exposure

Bookworm Pi OS has no firewall enabled by default on DEXI-OS. Verified by grepping `provision.sh`, `apt_packages.sh`, `setup_docker_containers.sh`, `setup_code_server.sh`, `first_boot.sh` for `ufw`/`iptables`/`firewalld`/`nftables` — zero matches. Port 8088 will be reachable as soon as the unit is up.

## Security note (for v0.20 release notes)

**No auth on `:8088`** in this release. Anyone on the LAN or `dexi_<MAC>` hotspot can issue MAV commands (incl. `MAV_CMD_NAV_TAKEOFF`). Same posture as the existing QGC-on-14550 exposure today, but more reachable via a browser. Acceptable for v0.20 — revisit hardening (Tailscale ephemeral nodes, session-token reverse proxy, or `cloudflared` tunnel + Cloudflare Access) in a follow-up.

## Test plan

After this PR + dexi_bringup#23 are merged, on a freshly-flashed image:

**On the drone (SSH):**
- [ ] `systemctl status mavlink2rest` → active, no errors
- [ ] `ss -tnlp | grep 8088` → bound to 0.0.0.0:8088
- [ ] `curl http://localhost:8088/v1/info` → JSON with `"version":"1.0.2"` and `"sha":"237c8899..."`
- [ ] `curl http://localhost:8088/v1/mavlink/vehicles` → returns the FC's sysid

**From a client on the LAN:**
- [ ] `curl http://<drone-ip>:8088/v1/info` → same response
- [ ] `curl http://<drone-ip>:8088/v1/mavlink/vehicles/1/components/1/messages/HEARTBEAT` → live HEARTBEAT JSON

**Pre-flash image inspection** (provision scripts swallow errors silently — verify the bake actually worked):
- [ ] Mount the `.img`, confirm `/usr/local/bin/mavlink2rest` exists, is ARM64 ELF (`file mavlink2rest`)
- [ ] `/etc/systemd/system/mavlink2rest.service` matches
- [ ] `/etc/systemd/system/multi-user.target.wants/mavlink2rest.service` symlink exists (proves `systemctl enable` fired in chroot)
- [ ] `/opt/cargo` and `/opt/rustup` are **absent** (toolchain cleanup worked)