### PR TITLE
feat(first_boot): --pid=host for dexi-droneblocks container

### DIFF
--- a/resources/first_boot.sh
+++ b/resources/first_boot.sh
@@ -22,7 +22,12 @@ chown -R dexi:dexi /home/dexi
 # Load DroneBlocks image from provision script since Docker isn't readily available during provisioning
 docker load < /home/dexi/docker-drag/droneblocks_dexi-droneblocks.tar
 docker load < /home/dexi/docker-drag/droneblocks_dexi-node-red.tar
-docker run -d --restart unless-stopped -p 80:3000 --name dexi-droneblocks droneblocks/dexi-droneblocks:latest
+# --pid=host: the GCS /status page's Top Processes panel calls `top` to list
+# CPU-heavy processes; without --pid=host the container only sees its own ~4
+# PIDs (the Nuxt server) and the panel is useless for diagnosing what's
+# actually loading the Pi. With it, the panel shows host PIDs like
+# rosbridge_websocket, micro_ros_agent, camera_node, etc.
+docker run -d --restart unless-stopped --pid=host -p 80:3000 --name dexi-droneblocks droneblocks/dexi-droneblocks:latest
 docker run -d --restart unless-stopped -p 1880:1880 -v /home/dexi/node-red-dexi/flows:/data --name dexi-node-red droneblocks/dexi-node-red:latest
 rm -rf /home/dexi/docker-drag
 


### PR DESCRIPTION
## Why

The `/status` page's Top Processes panel calls `top` inside the `dexi-droneblocks` container. Without `--pid=host`, the container only sees its own ~4 PIDs (the Nuxt server itself), so the panel returns either nothing or only Nuxt processes — useless for the actual question "what's loading the Pi."

## What changed

One-line addition to the `dexi-droneblocks` `docker run` command in `resources/first_boot.sh`. New invocation:

```bash
docker run -d --restart unless-stopped --pid=host -p 80:3000 --name dexi-droneblocks droneblocks/dexi-droneblocks:latest
```

## Companion PR

This pairs with [dexi-droneblocks PR #46](https://github.com/DroneBlocks/dexi-droneblocks/pull/46) which adds `procps` to the image (currently `top` is missing entirely from the slim node:20 base) and adds friendly-name resolution (so `python3` → `rosbridge_websocket`, etc.).

Either PR is graceful in isolation:
- **PR #46 alone**: panel works but shows only the Nuxt server's own ~4 PIDs
- **This PR alone**: panel still returns null because `top` is missing from the current image
- **Both together**: panel shows the full host workload with friendly ROS node names

## Verified live

On a CM5 running this work as a hot-patched container (apt-installed `procps` + recreated with `--pid=host`):

```
54.9%  rosbridge_websocket           770
21.6%  cam0                          780
13.7%  color_detection_node          794
 9.8%  image_throttle_raw_node       786
 3.9%  micro_ros_agent               768
```

## Side effects

`--pid=host` is a reduction in container isolation: the container can see (but not directly kill — it'd need additional capabilities) host process metadata. For DEXI's GCS container — already privileged enough to expose ports to the LAN and serve the flight UI — this is a benign relaxation. The container does not run untrusted code.

## Test plan

- [ ] Land [dexi-droneblocks PR #46](https://github.com/DroneBlocks/dexi-droneblocks/pull/46) and re-trigger that repo's `release.yml` workflow to publish the rebuilt image
- [ ] Push the new tar to R2 (`docker pull --platform linux/arm64 ...` → `docker save` → `rclone copyto`)
- [ ] Build a new dexi-os CM5 image, flash it, boot
- [ ] Navigate to `http://<pi-ip>/status` — confirm Top Processes panel shows ROS nodes with friendly names