### PR TITLE
Run node-red with --add-host=host.docker.internal:host-gateway

### DIFF
--- a/resources_raspberry_pi_os/setup_docker_containers.sh
+++ b/resources_raspberry_pi_os/setup_docker_containers.sh
@@ -143,7 +143,12 @@ if docker ps --format "table {{.Names}}" | grep -q "dexi-node-red"; then
     echo "DEXI Node-RED container already running"
 else
     echo "Starting DEXI Node-RED container..."
+    # --add-host=host.docker.internal:host-gateway lets the bridge-networked
+    # node-red reach rosbridge on the host (:9090) by a stable name, so the
+    # ROS2 websocket URL (ws://host.docker.internal:9090, baked into the image)
+    # keeps working regardless of the drone's LAN IP / AP-vs-network mode.
     docker run -d --restart unless-stopped -p 1880:1880 \
+        --add-host=host.docker.internal:host-gateway \
         -v /home/dexi/node-red-dexi/flows:/data \
         --name dexi-node-red droneblocks/dexi-node-red:latest
     echo "DEXI Node-RED container started"


### PR DESCRIPTION
Pairs with node-red-dexi PR #15. Adds `--add-host=host.docker.internal:host-gateway` to the node-red `docker run` so the bridge-networked container can resolve the host (where rosbridge listens on :9090) by a stable name. Together with the image default `ROS2_WEBSOCKET_URL=ws://host.docker.internal:9090`, this makes the ROS2 websocket IP-agnostic — no more hand-editing the URL when the drone joins a LAN. Verified live on a CM5.